### PR TITLE
Remove -u (update deps) paramter that is breaking :GlowInstall

### DIFF
--- a/lua/glow.lua
+++ b/lua/glow.lua
@@ -35,7 +35,7 @@ local function validate(path)
 end
 
 local function call_go_command()
-  local cmd = {"go", "get", "-u", "github.com/charmbracelet/glow"}
+  local cmd = {"go", "get", "github.com/charmbracelet/glow"}
   vim.fn.jobstart(cmd, {
     on_exit = function(_, d, _)
       if d == 0 then


### PR DESCRIPTION
When doing ```go get -u github.com/charmbracelet/glow``` GO is attempting to update the named packages
and their dependencies and this is causing the build to fail due to breaking changes.

This PR removes the ```-u``` parameter and ensures we only get and build known working deps.

Tested on Apple OS X and Linux