### PR TITLE
change default branch name for vim-plug

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A [glow](https://github.com/charmbracelet/glow) preview directly in your neovim 
 **NOTE: This plugin requires Neovim 0.5 versions**
 
 ```
-Plug 'npxbr/glow.nvim', {'do': ':GlowInstall'}
+Plug 'npxbr/glow.nvim', {'do': ':GlowInstall','branch':'main'}
 ```
 
 ## Usage


### PR DESCRIPTION
By default **vim-plug** is looking for **master** branch but **glow** is using **main**. If use doesn't specify this option then installation will fail
I just explicitly added the branch name into the install instruction 