### PR TITLE
Fix Glow installation issue #23

### DIFF
--- a/lua/glow.lua
+++ b/lua/glow.lua
@@ -42,6 +42,7 @@ local function call_install_script()
     # edge case for osx
     if [ "$os" == "darwin" ]; then
       os="Darwin"
+      arch=$(uname -m)
     fi
     [ -z "$arch" ] || [ "$arch" == "unknown" ] && arch="x86_64"
     filename="glow_${version}_${os}_${arch}.tar.gz"


### PR DESCRIPTION
This was failing for me atleast because `uname -p` gave i386.

According to this answer here https://unix.stackexchange.com/questions/518318/what-does-i386-mean-on-macos-mojave
the processor type is meant to differentiate between PowerPC and Intel x86, so the correct way would be to use `uname -m`