### PR TITLE
fix: don't require setting `glow_binary_path` if `glow` is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,16 @@ use {"ellisonleao/glow.nvim"}
 
 ## Configuration
 
-- Binary path
+- `glow_binary_path`
 
-This config will be used to set where the `glow` binary is installed if already available in `$PATH`. Same path will be
-used if you need to download it
+Use `g:glow_binary_path` for vimscript config or `vim.g.glow_binary_path` for lua config.
 
-Use `g:glow_binary_path` for vimscript config or `vim.g.glow_binary_path` for lua config. Example:
+If set, this path will be used to execute `glow`. Otherwise rely on `$PATH`.
+
+If `glow` is not on `$PATH` or `glow_binary_path` is set and `glow` is not found
+there, this path will be used to download the `glow` executable. It defaults to `$HOME/.local/bin`.
+
+Example:
 
 ```viml
 let g:glow_binary_path = $HOME . "/bin"
@@ -36,9 +40,6 @@ let g:glow_binary_path = $HOME . "/bin"
 ```lua
 vim.g.glow_binary_path = vim.env.HOME .. "/bin"
 ```
-
-If no config is available, the default path will be `$HOME/.local/bin` . Make sure to add it into `$PATH` if that's the
-case.
 
 ## Usage
 

--- a/lua/glow.lua
+++ b/lua/glow.lua
@@ -4,6 +4,11 @@ local bin_path = vim.g.glow_binary_path
 if bin_path == nil then
   bin_path = vim.env.HOME .. "/.local/bin"
 end
+
+local use_path_glow = vim.g.glow_binary_path == nil and vim.fn.executable("glow") == 1
+
+local glow_path = use_path_glow and "glow" or bin_path .. "/glow"
+
 local M = {}
 
 local function has_value(tab, val)
@@ -16,7 +21,7 @@ local function has_value(tab, val)
 end
 
 local function validate(path)
-  if vim.fn.executable(bin_path .. "/glow") == 0 then
+  if vim.fn.executable(glow_path) == 0 then
     return M.download_glow()
   end
 
@@ -194,7 +199,7 @@ local function open_window(path)
   api.nvim_buf_set_keymap(buf, "n", "<Esc>", ":lua require('glow').close_window()<cr>",
                           {noremap = true, silent = true})
 
-  vim.fn.termopen(string.format("%s/glow %s", bin_path, vim.fn.shellescape(path)))
+  vim.fn.termopen(string.format("%s %s", glow_path, vim.fn.shellescape(path)))
 end
 
 function M.glow(file)


### PR DESCRIPTION
If `glow` is available on `$PATH` and we haven't explicitly set `glow_binary_path` then just execute `"glow"`.